### PR TITLE
feat: implement ios version of the keycommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ const SEARCH_COMMAND = {input: 'd', modifierFlags: KeyCommand.constants.keyModif
 /**
  * Register a command for [k + CMD] combination
  */
-KeyCommand.registerKeyCommand([SEARCH_COMMAND]);
+KeyCommand.registerKeyCommands([SEARCH_COMMAND]);
 
 /**
  * Add a global event listener that will trigger when any
@@ -46,7 +46,7 @@ KeyCommand.eventEmitter.addListener('onKeyCommand', console.log);
 /**
  * Unregister keycommand
  */
-KeyCommand.unregisterKeyCommand([SEARCH_COMMAND]);
+KeyCommand.unregisterKeyCommands([SEARCH_COMMAND]);
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -9,11 +9,21 @@ npm install react-native-key-command
 ## Usage
 
 ```js
-import { multiply } from "react-native-key-command";
+import {registerKeyCommand, constants, eventEmitter} from 'react-native-key-command';
 
 // ...
 
-const result = await multiply(3, 7);
+/**
+ * Register a command for [k + CMD] combination
+ */
+registerKeyCommand([
+  {input: 'd', modifierFlags: constants.keyModifierCommand},
+]);
+
+/**
+ * Add an event listener
+ */
+eventEmitter.addListener('onKeyCommand', console.log);
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -9,21 +9,21 @@ npm install react-native-key-command
 ## Usage
 
 ```js
-import {registerKeyCommand, constants, eventEmitter} from 'react-native-key-command';
+import * as KeyCommand from 'react-native-key-command';
 
 // ...
 
 /**
  * Register a command for [k + CMD] combination
  */
-registerKeyCommand([
-  {input: 'd', modifierFlags: constants.keyModifierCommand},
+KeyCommand.registerKeyCommand([
+  {input: 'd', modifierFlags: KeyCommand.constants.keyModifierCommand},
 ]);
 
 /**
  * Add an event listener
  */
-eventEmitter.addListener('onKeyCommand', console.log);
+KeyCommand.eventEmitter.addListener('onKeyCommand', console.log);
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ React.useEffect(() => {
 }, []);
 ```
 
-Imperative API provides you with a granular control over the library, e.g:
-- Declare multiple commands at once
-- Declare command in your React component (components/Shortcuts.js) and attach listener globally in your root component (Router.js)
-- Implement decoupled Register / Unregister commands
+Imperative API provides you with granular control over the library, e.g:
+- Declare multiple commands at once.
+- Declare command in your React component (components/Shortcuts.js) and attach listener globally in your root component (Router.js).
+- Implement decoupled Register / Unregister commands.
 
 ```js
 import * as KeyCommand from 'react-native-key-command';

--- a/README.md
+++ b/README.md
@@ -7,23 +7,46 @@ npm install react-native-key-command
 ```
 
 ## Usage
-
 ```js
 import * as KeyCommand from 'react-native-key-command';
 
 // ...
 
+React.useEffect(() => {
+    const SEARCH_COMMAND = {input: 'f', modifierFlags: KeyCommand.constants.keyModifierCommand};
+    return KeyCommand.addListener(SEARCH_COMMAND, console.log);
+}, []);
+```
+
+Imperative Usage
+```js
+import * as KeyCommand from 'react-native-key-command';
+
+// ...
+
+const SEARCH_COMMAND = {input: 'd', modifierFlags: KeyCommand.constants.keyModifierCommand};
+
 /**
  * Register a command for [k + CMD] combination
  */
-KeyCommand.registerKeyCommand([
-  {input: 'd', modifierFlags: KeyCommand.constants.keyModifierCommand},
-]);
+KeyCommand.registerKeyCommand([SEARCH_COMMAND]);
 
 /**
- * Add an event listener
+ * Add a global event listener that will trigger when any
+ * registered keycommand is pressed
  */
 KeyCommand.eventEmitter.addListener('onKeyCommand', console.log);
+
+/**
+ * Add a global event listener that will trigger when any
+ * registered keycommand is pressed
+ */
+KeyCommand.eventEmitter.addListener('onKeyCommand', console.log);
+
+/**
+ * Unregister keycommand
+ */
+KeyCommand.unregisterKeyCommand([SEARCH_COMMAND]);
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ React.useEffect(() => {
 }, []);
 ```
 
-Imperative Usage
+Imperative API provides you with a granular control over the library, e.g:
+- Declare multiple commands at once
+- Declare command in your React component (components/Shortcuts.js) and attach listener globally in your root component (Router.js)
+- Implement decoupled Register / Unregister commands
+
 ```js
 import * as KeyCommand from 'react-native-key-command';
 
@@ -56,7 +60,3 @@ See the [contributing guide](CONTRIBUTING.md) to learn how to contribute to the 
 ## License
 
 MIT
-
----
-
-Made with [create-react-native-library](https://github.com/callstack/react-native-builder-bob)

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -1,26 +1,63 @@
 import * as React from 'react';
+import {
+    // eslint-disable-next-line no-restricted-imports
+    SafeAreaView, StyleSheet, ScrollView, Text,
+} from 'react-native';
 import * as KeyCommand from 'react-native-key-command';
+import _ from 'underscore';
+
+const styles = StyleSheet.create({
+    container: {
+        backgroundColor: '#fff',
+        flex: 1,
+    },
+    title: {
+        padding: 12,
+        fontSize: 16,
+        fontWeight: '500',
+    },
+    scroll: {
+        padding: 12,
+        borderTopWidth: 1,
+        borderTopColor: '#333',
+    },
+});
 
 export default function App() {
-    React.useEffect(() => {
-        const searchCommandId = {input: 'f', modifierFlags: KeyCommand.constants.keyModifierCommand};
+    const [history, setHistory] = React.useState([]);
 
+    const handleSearchCommandPress = React.useCallback((response) => {
+        setHistory(state => state.concat(response));
+    });
+
+    React.useEffect(() => {
+        const SEARCH_COMMAND = {input: 'f', modifierFlags: KeyCommand.constants.keyModifierCommand};
         KeyCommand.registerKeyCommand([
-            searchCommandId,
+            SEARCH_COMMAND,
         ]);
 
         return () => {
-            KeyCommand.unregisterKeyCommand([searchCommandId]);
+            KeyCommand.unregisterKeyCommand([SEARCH_COMMAND]);
         };
     }, []);
 
     React.useEffect(() => {
-        const handleKeyCommand = () => {};
-        const subscription = KeyCommand.eventEmitter.addListener('onKeyCommand', handleKeyCommand);
+        const subscription = KeyCommand.eventEmitter.addListener('onKeyCommand', handleSearchCommandPress);
         return () => {
             subscription.remove();
         };
     }, []);
 
-    return null;
+    return (
+        <SafeAreaView style={styles.container}>
+            <Text style={styles.title}>Press [CMD + F] to trigger keycommand events</Text>
+
+            <ScrollView style={styles.scroll}>
+                {_.map(history, (response, index) => (
+                    <Text key={index}>{JSON.stringify(response, null, 2)}</Text>
+                ))}
+            </ScrollView>
+        </SafeAreaView>
+    );
 }
+

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -32,20 +32,7 @@ export default function App() {
 
     React.useEffect(() => {
         const SEARCH_COMMAND = {input: 'f', modifierFlags: KeyCommand.constants.keyModifierCommand};
-        KeyCommand.registerKeyCommand([
-            SEARCH_COMMAND,
-        ]);
-
-        return () => {
-            KeyCommand.unregisterKeyCommand([SEARCH_COMMAND]);
-        };
-    }, []);
-
-    React.useEffect(() => {
-        const subscription = KeyCommand.eventEmitter.addListener('onKeyCommand', handleSearchCommandPress);
-        return () => {
-            subscription.remove();
-        };
+        return KeyCommand.addListener(SEARCH_COMMAND, handleSearchCommandPress);
     }, []);
 
     return (

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -17,7 +17,8 @@ export default function App() {
     }, []);
 
     React.useEffect(() => {
-        const subscription = eventEmitter.addListener('onKeyCommand', console.log);
+        const handleKeyCommand = () => {};
+        const subscription = eventEmitter.addListener('onKeyCommand', handleKeyCommand);
         return () => {
             subscription.remove();
         };

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -28,7 +28,7 @@ export default function App() {
 
     const handleSearchCommandPress = React.useCallback((response) => {
         setHistory(state => state.concat(response));
-    });
+    }, []);
 
     React.useEffect(() => {
         const SEARCH_COMMAND = {input: 'f', modifierFlags: KeyCommand.constants.keyModifierCommand};

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -1,10 +1,28 @@
 import * as React from 'react';
-import {View} from 'react-native';
-import {getConstants} from 'react-native-key-command';
+import {
+    registerKeyCommand, unregisterKeyCommand, constants, eventEmitter,
+} from 'react-native-key-command';
 
 export default function App() {
-    return (
-        <View />
-    );
+    React.useEffect(() => {
+        const searchCommandId = {input: 'd', modifierFlags: constants.keyModifierCommand};
+
+        registerKeyCommand([
+            {input: 'd', modifierFlags: constants.keyModifierCommand},
+        ]);
+
+        return () => {
+            unregisterKeyCommand([searchCommandId]);
+        };
+    }, []);
+
+    React.useEffect(() => {
+        const subscription = eventEmitter.addListener('onKeyCommand', console.log);
+        return () => {
+            subscription.remove();
+        };
+    }, []);
+
+    return null;
 }
 

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -1,12 +1,8 @@
 import * as React from 'react';
 import {View} from 'react-native';
-import {multiply} from 'react-native-key-command';
+import {getConstants} from 'react-native-key-command';
 
 export default function App() {
-    React.useEffect(() => {
-        multiply(3, 7);
-    }, []);
-
     return (
         <View />
     );

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -1,24 +1,22 @@
 import * as React from 'react';
-import {
-    registerKeyCommand, unregisterKeyCommand, constants, eventEmitter,
-} from 'react-native-key-command';
+import * as KeyCommand from 'react-native-key-command';
 
 export default function App() {
     React.useEffect(() => {
-        const searchCommandId = {input: 'd', modifierFlags: constants.keyModifierCommand};
+        const searchCommandId = {input: 'f', modifierFlags: KeyCommand.constants.keyModifierCommand};
 
-        registerKeyCommand([
-            {input: 'd', modifierFlags: constants.keyModifierCommand},
+        KeyCommand.registerKeyCommand([
+            searchCommandId,
         ]);
 
         return () => {
-            unregisterKeyCommand([searchCommandId]);
+            KeyCommand.unregisterKeyCommand([searchCommandId]);
         };
     }, []);
 
     React.useEffect(() => {
         const handleKeyCommand = () => {};
-        const subscription = eventEmitter.addListener('onKeyCommand', handleKeyCommand);
+        const subscription = KeyCommand.eventEmitter.addListener('onKeyCommand', handleKeyCommand);
         return () => {
             subscription.remove();
         };
@@ -26,4 +24,3 @@ export default function App() {
 
     return null;
 }
-

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {
-    // eslint-disable-next-line no-restricted-imports
     SafeAreaView, StyleSheet, ScrollView, Text,
 } from 'react-native';
 import * as KeyCommand from 'react-native-key-command';

--- a/ios/KeyCommand.h
+++ b/ios/KeyCommand.h
@@ -1,5 +1,33 @@
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+#import <UIKit/UIKit.h>
 
-@interface KeyCommand : NSObject <RCTBridgeModule>
+@interface KeyCommand : RCTEventEmitter <RCTBridgeModule>
+
+@end
+
+
+@interface HardwareKeyCommands : NSObject
+
++ (instancetype)sharedInstance;
+
+/**
+ * Register a keyboard command.
+ */
+- (void)registerKeyCommandWithInput:(NSString *)input
+                      modifierFlags:(UIKeyModifierFlags)flags
+                             action:(void (^)(UIKeyCommand *command))block;
+
+/**
+ * Unregister a keyboard command.
+ */
+- (void)unregisterKeyCommandWithInput:(NSString *)input
+                        modifierFlags:(UIKeyModifierFlags)flags;
+
+/**
+ * Check if a command is registered.
+ */
+- (BOOL)isKeyCommandRegisteredForInput:(NSString *)input
+                         modifierFlags:(UIKeyModifierFlags)flags;
 
 @end

--- a/ios/KeyCommand.mm
+++ b/ios/KeyCommand.mm
@@ -279,8 +279,8 @@ RCT_EXPORT_MODULE()
     };
 }
 
-RCT_REMAP_METHOD(registerKeyCommand,
-                 registerKeyCommand:(NSArray *)json
+RCT_REMAP_METHOD(registerKeyCommands,
+                 registerKeyCommands:(NSArray *)json
                  withResolver:(RCTPromiseResolveBlock)resolve
                  withRejecter:(RCTPromiseRejectBlock)reject)
 {
@@ -311,8 +311,8 @@ RCT_REMAP_METHOD(registerKeyCommand,
   resolve(nil);
 }
 
-RCT_REMAP_METHOD(unregisterKeyCommand,
-                 unregisterKeyCommand:(NSArray *)json
+RCT_REMAP_METHOD(unregisterKeyCommands,
+                 unregisterKeyCommands:(NSArray *)json
                  withResolver:(RCTPromiseResolveBlock)resolve
                  withRejecter:(RCTPromiseRejectBlock)reject)
 {

--- a/ios/KeyCommand.mm
+++ b/ios/KeyCommand.mm
@@ -1,31 +1,341 @@
 #import "KeyCommand.h"
+#import <UIKit/UIKit.h>
+#import <objc/message.h>
+#import <objc/runtime.h>
+#import "RCTDefines.h"
+#import "RCTUtils.h"
 
-#ifdef RCT_NEW_ARCH_ENABLED
-#import "RNKeyCommandSpec.h"
-#endif
+@interface UIEvent (UIPhysicalKeyboardEvent)
+
+@property (nonatomic) NSString *_modifiedInput;
+@property (nonatomic) NSString *_unmodifiedInput;
+@property (nonatomic) UIKeyModifierFlags _modifierFlags;
+@property (nonatomic) BOOL _isKeyDown;
+@property (nonatomic) long _keyCode;
+
+@end
+
+@interface HardwareKeyCommand : NSObject <NSCopying>
+
+@property (nonatomic, copy, readonly) NSString *key;
+@property (nonatomic, readonly) UIKeyModifierFlags flags;
+@property (nonatomic, copy) void (^block)(UIKeyCommand *);
+
+@end
+
+@implementation HardwareKeyCommand
+
+- (instancetype)init:(NSString *)key flags:(UIKeyModifierFlags)flags block:(void (^)(UIKeyCommand *))block
+{
+  if ((self = [super init])) {
+    _key = key;
+    _flags = flags;
+    _block = block;
+  }
+  return self;
+}
+
+RCT_NOT_IMPLEMENTED(-(instancetype)init)
+
+- (id)copyWithZone:(__unused NSZone *)zone
+{
+  return self;
+}
+
+- (NSUInteger)hash
+{
+  return _key.hash ^ _flags;
+}
+
+- (BOOL)isEqual:(HardwareKeyCommand *)object
+{
+  if (![object isKindOfClass:[HardwareKeyCommand class]]) {
+    return NO;
+  }
+  return [self matchesInput:object.key flags:object.flags];
+}
+
+- (BOOL)matchesInput:(NSString *)input flags:(UIKeyModifierFlags)flags
+{
+  return [_key isEqual:[input lowercaseString]] && _flags == flags;
+}
+
+- (NSString *)description
+{
+  return [NSString stringWithFormat:@"<%@:%p input=\"%@\" flags=%lld hasBlock=%@>",
+                                    [self class],
+                                    self,
+                                    _key,
+                                    (long long)_flags,
+                                    _block ? @"YES" : @"NO"];
+}
+
+@end
+
+@interface HardwareKeyCommands ()
+
+@property (nonatomic, strong) NSMutableSet<HardwareKeyCommand *> *commands;
+
+@end
+
+@implementation HardwareKeyCommands
+
++ (void)initialize
+{
+  SEL originalKeyEventSelector = NSSelectorFromString(@"handleKeyUIEvent:");
+  SEL swizzledKeyEventSelector = NSSelectorFromString(
+      [NSString stringWithFormat:@"_rct_swizzle_%x_%@", arc4random(), NSStringFromSelector(originalKeyEventSelector)]);
+
+  void (^handleKeyUIEventSwizzleBlock)(UIApplication *, UIEvent *) = ^(UIApplication *slf, UIEvent *event) {
+    [[[self class] sharedInstance] handleKeyUIEventSwizzle:event];
+
+    ((void (*)(id, SEL, id))objc_msgSend)(slf, swizzledKeyEventSelector, event);
+  };
+
+  RCTSwapInstanceMethodWithBlock(
+      [UIApplication class], originalKeyEventSelector, handleKeyUIEventSwizzleBlock, swizzledKeyEventSelector);
+}
+
+- (void)handleKeyUIEventSwizzle:(UIEvent *)event
+{
+  NSString *unmodifiedInput = nil;
+  NSString *modifiedInput = nil;
+  UIKeyModifierFlags modifierFlags = 0;
+  BOOL isKeyDown = NO;
+  long keyCode = 0;
+
+  if ([event respondsToSelector:@selector(_unmodifiedInput)]) {
+    unmodifiedInput = [event _unmodifiedInput];
+  }
+
+  if ([event respondsToSelector:@selector(_modifiedInput)]) {
+    modifiedInput = [event _modifiedInput];
+  }
+
+  if ([event respondsToSelector:@selector(_modifierFlags)]) {
+    modifierFlags = [event _modifierFlags];
+  }
+
+  if ([event respondsToSelector:@selector(_isKeyDown)]) {
+    isKeyDown = [event _isKeyDown];
+  }
+
+  if ([event respondsToSelector:@selector(_keyCode)]) {
+    keyCode = [event _keyCode];
+  }
+
+  BOOL interactionEnabled = !UIApplication.sharedApplication.isIgnoringInteractionEvents;
+  BOOL hasFirstResponder = NO;
+  if (isKeyDown && modifiedInput.length > 0 && interactionEnabled) {
+    UIResponder *firstResponder = nil;
+    for (UIWindow *window in [self allWindows]) {
+      firstResponder = [window valueForKey:@"firstResponder"];
+      if (firstResponder) {
+        hasFirstResponder = YES;
+        break;
+      }
+    }
+
+    // Ignore key commands (except escape) when there's an active responder
+    if (!firstResponder) {
+      [self RCT_handleKeyCommand:unmodifiedInput flags:modifierFlags];
+    }
+  }
+};
+
+- (NSArray<UIWindow *> *)allWindows
+{
+  BOOL includeInternalWindows = YES;
+  BOOL onlyVisibleWindows = NO;
+
+  // Obfuscating selector allWindowsIncludingInternalWindows:onlyVisibleWindows:
+  NSArray<NSString *> *allWindowsComponents =
+      @[ @"al", @"lWindo", @"wsIncl", @"udingInt", @"ernalWin", @"dows:o", @"nlyVisi", @"bleWin", @"dows:" ];
+  SEL allWindowsSelector = NSSelectorFromString([allWindowsComponents componentsJoinedByString:@""]);
+
+  NSMethodSignature *methodSignature = [[UIWindow class] methodSignatureForSelector:allWindowsSelector];
+  NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:methodSignature];
+
+  invocation.target = [UIWindow class];
+  invocation.selector = allWindowsSelector;
+  [invocation setArgument:&includeInternalWindows atIndex:2];
+  [invocation setArgument:&onlyVisibleWindows atIndex:3];
+  [invocation invoke];
+
+  __unsafe_unretained NSArray<UIWindow *> *windows = nil;
+  [invocation getReturnValue:&windows];
+  return windows;
+}
+
++ (instancetype)voidCompletionBlock
+{
+  return nil;
+}
+
+- (void)RCT_handleKeyCommand:(NSString *)input flags:(UIKeyModifierFlags)modifierFlags
+{
+  for (HardwareKeyCommand *command in [HardwareKeyCommands sharedInstance].commands) {
+    if ([command matchesInput:input flags:modifierFlags]) {
+      if (command.block) {
+        UIKeyCommand *keycommand = [UIKeyCommand keyCommandWithInput:input modifierFlags:modifierFlags action:@selector(voidCompletionBlock:)];
+        command.block(keycommand);
+      }
+    }
+  }
+}
+
++ (instancetype)sharedInstance
+{
+  static HardwareKeyCommands *sharedInstance;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    sharedInstance = [self new];
+  });
+
+  return sharedInstance;
+}
+
+- (instancetype)init
+{
+  if ((self = [super init])) {
+    _commands = [NSMutableSet new];
+  }
+  return self;
+}
+
+- (void)registerKeyCommandWithInput:(NSString *)input
+                      modifierFlags:(UIKeyModifierFlags)flags
+                             action:(void (^)(UIKeyCommand *))block
+{
+  RCTAssertMainQueue();
+
+  HardwareKeyCommand *keyCommand = [[HardwareKeyCommand alloc] init:input flags:flags block:block];
+  [_commands removeObject:keyCommand];
+  [_commands addObject:keyCommand];
+}
+
+- (void)unregisterKeyCommandWithInput:(NSString *)input modifierFlags:(UIKeyModifierFlags)flags
+{
+  RCTAssertMainQueue();
+
+  for (HardwareKeyCommand *command in _commands.allObjects) {
+    if ([command matchesInput:input flags:flags]) {
+      [_commands removeObject:command];
+      break;
+    }
+  }
+}
+
+- (BOOL)isKeyCommandRegisteredForInput:(NSString *)input modifierFlags:(UIKeyModifierFlags)flags
+{
+  RCTAssertMainQueue();
+
+  for (HardwareKeyCommand *command in _commands) {
+    if ([command matchesInput:input flags:flags]) {
+      return YES;
+    }
+  }
+  return NO;
+}
+
+@end
+
+
 
 @implementation KeyCommand
+
 RCT_EXPORT_MODULE()
 
-// Example method
-// See // https://reactnative.dev/docs/native-modules-ios
-RCT_REMAP_METHOD(multiply,
-                 multiplyWithA:(double)a withB:(double)b
++ (BOOL)requiresMainQueueSetup
+{
+  return YES;
+}
+
+- (NSArray<NSString *> *)supportedEvents
+{
+  return @[@"onKeyCommand"];
+}
+
+- (NSDictionary *)constantsToExport {
+    return @{
+         @"keyModifierCapsLock": @(UIKeyModifierAlphaShift),
+         @"keyModifierShift": @(UIKeyModifierShift),
+         @"keyModifierControl": @(UIKeyModifierControl),
+         @"keyModifierOption": @(UIKeyModifierAlternate),
+         @"keyModifierCommand": @(UIKeyModifierCommand),
+
+         @"keyModifierControlOption": @(UIKeyModifierControl | UIKeyModifierAlternate),
+         @"keyModifierControlOptionCommand": @(UIKeyModifierControl | UIKeyModifierAlternate | UIKeyModifierCommand),
+         @"keyModifierControlCommand": @(UIKeyModifierControl | UIKeyModifierCommand),
+         @"keyModifierOptionCommand": @(UIKeyModifierAlternate | UIKeyModifierCommand),
+         @"keyModifierShiftCommand": @(UIKeyModifierShift | UIKeyModifierCommand),
+
+         @"keyModifierNumericPad": @(UIKeyModifierNumericPad),
+         @"keyInputUpArrow": UIKeyInputUpArrow,
+         @"keyInputDownArrow": UIKeyInputDownArrow,
+         @"keyInputLeftArrow": UIKeyInputLeftArrow,
+         @"keyInputRightArrow": UIKeyInputRightArrow,
+         @"keyInputEscape": UIKeyInputEscape
+    };
+}
+
+RCT_REMAP_METHOD(registerKeyCommand,
+                 registerKeyCommand:(NSArray *)json
                  withResolver:(RCTPromiseResolveBlock)resolve
                  withRejecter:(RCTPromiseRejectBlock)reject)
 {
-  NSNumber *result = @(a * b);
 
-  resolve(result);
+  NSArray<NSDictionary *> *commandsArray = json;
+
+  for (NSDictionary *commandJSON in commandsArray) {
+      NSString *input = commandJSON[@"input"];
+      NSNumber *flags = commandJSON[@"modifierFlags"];
+
+      if (!flags) {
+          flags = @0;
+      }
+
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [[HardwareKeyCommands sharedInstance]
+            registerKeyCommandWithInput:input
+            modifierFlags:[flags integerValue]
+            action:^(__unused UIKeyCommand *command) {
+              [self sendEventWithName:@"onKeyCommand" body:@{
+                   @"input": [command.input lowercaseString],
+                   @"modifierFlags": [NSNumber numberWithInteger:command.modifierFlags]
+              }];
+            }];
+      });
+  }
+
+  resolve(nil);
 }
 
-// Don't compile this code when we build for the old architecture.
-#ifdef RCT_NEW_ARCH_ENABLED
-- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
-    (const facebook::react::ObjCTurboModule::InitParams &)params
+RCT_REMAP_METHOD(unregisterKeyCommand,
+                 unregisterKeyCommand:(NSArray *)json
+                 withResolver:(RCTPromiseResolveBlock)resolve
+                 withRejecter:(RCTPromiseRejectBlock)reject)
 {
-    return std::make_shared<facebook::react::NativeKeyCommandSpecJSI>(params);
+
+  NSArray<NSDictionary *> *commandsArray = json;
+
+  for (NSDictionary *commandJSON in commandsArray) {
+      NSString *input = commandJSON[@"input"];
+      NSNumber *flags = commandJSON[@"modifierFlags"];
+
+      if (!flags) {
+          flags = @0;
+      }
+
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [[HardwareKeyCommands sharedInstance]
+            unregisterKeyCommandWithInput:input
+            modifierFlags:[flags integerValue]
+        ];
+      });
+  }
+
+  resolve(nil);
 }
-#endif
 
 @end

--- a/ios/KeyCommand.mm
+++ b/ios/KeyCommand.mm
@@ -80,6 +80,25 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
 
 @implementation HardwareKeyCommands
 
+- (instancetype)init
+{
+  if ((self = [super init])) {
+    _commands = [NSMutableSet new];
+  }
+  return self;
+}
+
++ (instancetype)sharedInstance
+{
+  static HardwareKeyCommands *sharedInstance;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    sharedInstance = [self new];
+  });
+
+  return sharedInstance;
+}
+
 + (void)initialize
 {
   SEL originalKeyEventSelector = NSSelectorFromString(@"handleKeyUIEvent:");
@@ -182,25 +201,6 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
       }
     }
   }
-}
-
-+ (instancetype)sharedInstance
-{
-  static HardwareKeyCommands *sharedInstance;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    sharedInstance = [self new];
-  });
-
-  return sharedInstance;
-}
-
-- (instancetype)init
-{
-  if ((self = [super init])) {
-    _commands = [NSMutableSet new];
-  }
-  return self;
 }
 
 - (void)registerKeyCommandWithInput:(NSString *)input

--- a/package.json
+++ b/package.json
@@ -97,7 +97,10 @@
     "parser": "@babel/eslint-parser",
     "extends": [
       "expensify"
-    ]
+    ],
+    "rules": {
+      "no-restricted-imports": 0
+    }
   },
   "eslintIgnore": [
     "node_modules/",

--- a/src/index.js
+++ b/src/index.js
@@ -15,12 +15,20 @@ const KeyCommand = NativeModules.KeyCommand ? NativeModules.KeyCommand : new Pro
     },
 );
 
-function constants() {
-    return KeyCommand.constants();
+function getConstants() {
+    return KeyCommand.getConstants();
 }
 
-function multiply(a, b) {
-    return KeyCommand.multiply(a, b);
+function registerKeyCommand(a, b) {
+    return KeyCommand.registerKeyCommand(a, b);
 }
 
-export {multiply, constants};
+function unregisterKeyCommand(a, b) {
+    return KeyCommand.unregisterKeyCommand(a, b);
+}
+
+export {
+    registerKeyCommand,
+    unregisterKeyCommand,
+    getConstants,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ const eventEmitter = getEventEmitter();
  *
  * @param {string} keyCommand - Event name to listen to.
  * @param {Function} callback - Callback to be called when the event is triggered.
- * @returns {Function} eventListener instance to register a callback.
+ * @returns {Function} clear callback function to be called when component unmounts.
  */
 function addListener(keyCommand, callback) {
     registerKeyCommand([keyCommand]);

--- a/src/index.js
+++ b/src/index.js
@@ -32,8 +32,8 @@ function getConstants() {
  * @param {number} keyCommands[].modifierFlags - predefined command from getConstants enum.
  * @returns {Promise}
  */
-function registerKeyCommand(keyCommands) {
-    return KeyCommand.registerKeyCommand(keyCommands);
+function registerKeyCommands(keyCommands) {
+    return KeyCommand.registerKeyCommands(keyCommands);
 }
 
 /**
@@ -44,8 +44,8 @@ function registerKeyCommand(keyCommands) {
  * @param {number} keyCommands[].modifierFlags - predefined command from getConstants enum.
  * @returns {Promise}
  */
-function unregisterKeyCommand(keyCommands) {
-    return KeyCommand.unregisterKeyCommand(keyCommands);
+function unregisterKeyCommands(keyCommands) {
+    return KeyCommand.unregisterKeyCommands(keyCommands);
 }
 
 /**
@@ -68,7 +68,7 @@ const eventEmitter = getEventEmitter();
  * @returns {Function} clear callback function to be called when component unmounts.
  */
 function addListener(keyCommand, callback) {
-    registerKeyCommand([keyCommand]);
+    registerKeyCommands([keyCommand]);
     const event = eventEmitter.addListener('onKeyCommand', (response) => {
         if (response.input !== keyCommand.input || response.modifierFlags !== keyCommand.modifierFlags) {
             return;
@@ -79,13 +79,13 @@ function addListener(keyCommand, callback) {
 
     return () => {
         event.remove();
-        unregisterKeyCommand([keyCommand]);
+        unregisterKeyCommands([keyCommand]);
     };
 }
 
 export {
-    registerKeyCommand,
-    unregisterKeyCommand,
+    registerKeyCommands,
+    unregisterKeyCommands,
     constants,
     eventEmitter,
     addListener,

--- a/src/index.js
+++ b/src/index.js
@@ -15,18 +15,44 @@ const KeyCommand = NativeModules.KeyCommand ? NativeModules.KeyCommand : new Pro
     },
 );
 
+/**
+ * predefined multiplatform commands list.
+ *
+ * @returns {Object} predefined command from getConstants enum.
+ */
 function getConstants() {
     return KeyCommand.getConstants();
 }
 
+/**
+ * Registers key command combination list.
+ *
+ * @param {Object[]} keyCommands - List of key command objects.
+ * @param {string} keyCommands[].input - any character key from the keyboard.
+ * @param {number} keyCommands[].modifierFlags - predefined command from getConstants enum.
+ * @returns {Promise}
+ */
 function registerKeyCommand(keyCommands) {
     return KeyCommand.registerKeyCommand(keyCommands);
 }
 
+/**
+ * Unregister key command combination list.
+ *
+ * @param {Object[]} keyCommands - List of key command objects.
+ * @param {string} keyCommands[].input - any character key from the keyboard.
+ * @param {number} keyCommands[].modifierFlags - predefined command from getConstants enum.
+ * @returns {Promise}
+ */
 function unregisterKeyCommand(keyCommands) {
     return KeyCommand.unregisterKeyCommand(keyCommands);
 }
 
+/**
+ * Key command Event listener.
+ *
+ * @returns {Object} eventListener instance to register a callback.
+ */
 function getEventEmitter() {
     return new NativeEventEmitter(KeyCommand);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const KeyCommand = NativeModules.KeyCommand ? NativeModules.KeyCommand : new Pro
 );
 
 /**
- * predefined multiplatform commands list.
+ * Predefined multiplatform commands list.
  *
  * @returns {Object} predefined command from getConstants enum.
  */
@@ -61,11 +61,11 @@ const constants = getConstants();
 const eventEmitter = getEventEmitter();
 
 /**
- * Key command Event listener.
+ * Register key command and listen to the event.
  *
- * @param {string} keyCommand - Event name to listen to.
+ * @param {string} keyCommand - Key command combination.
  * @param {Function} callback - Callback to be called when the event is triggered.
- * @returns {Function} clear callback function to be called when component unmounts.
+ * @returns {Function} callback to remove the subscription.
  */
 function addListener(keyCommand, callback) {
     registerKeyCommands([keyCommand]);

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import {NativeModules, Platform} from 'react-native';
+import {NativeModules, NativeEventEmitter, Platform} from 'react-native';
 
 const PLATFORM_ERROR_MESSAGE = Platform.select({ios: "- You have run 'pod install'\n", default: ''});
 const LINKING_ERROR = `The package 'react-native-key-command' doesn't seem to be linked. Make sure: \n\n
@@ -19,16 +19,24 @@ function getConstants() {
     return KeyCommand.getConstants();
 }
 
-function registerKeyCommand(a, b) {
-    return KeyCommand.registerKeyCommand(a, b);
+function registerKeyCommand(keyCommands) {
+    return KeyCommand.registerKeyCommand(keyCommands);
 }
 
-function unregisterKeyCommand(a, b) {
-    return KeyCommand.unregisterKeyCommand(a, b);
+function unregisterKeyCommand(keyCommands) {
+    return KeyCommand.unregisterKeyCommand(keyCommands);
 }
+
+function getEventEmitter() {
+    return new NativeEventEmitter(KeyCommand);
+}
+
+const constants = getConstants();
+const eventEmitter = getEventEmitter();
 
 export {
     registerKeyCommand,
     unregisterKeyCommand,
-    getConstants,
+    constants,
+    eventEmitter,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,10 @@ const eventEmitter = getEventEmitter();
 /**
  * Register key command and listen to the event.
  *
- * @param {string} keyCommand - Key command combination.
+ * @param {Object} keyCommand - List of key command objects.
+ * @param {string} keyCommand.input - any character key from the keyboard.
+ * @param {number} keyCommand.modifierFlags - predefined command from getConstants enum.
+ *
  * @param {Function} callback - Callback to be called when the event is triggered.
  * @returns {Function} callback to remove the subscription.
  */

--- a/src/index.js
+++ b/src/index.js
@@ -60,9 +60,33 @@ function getEventEmitter() {
 const constants = getConstants();
 const eventEmitter = getEventEmitter();
 
+/**
+ * Key command Event listener.
+ *
+ * @param {string} keyCommand - Event name to listen to.
+ * @param {Function} callback - Callback to be called when the event is triggered.
+ * @returns {Function} eventListener instance to register a callback.
+ */
+function addListener(keyCommand, callback) {
+    registerKeyCommand([keyCommand]);
+    const event = eventEmitter.addListener('onKeyCommand', (response) => {
+        if (response.input !== keyCommand.input || response.modifierFlags !== keyCommand.modifierFlags) {
+            return;
+        }
+
+        callback(response);
+    });
+
+    return () => {
+        event.remove();
+        unregisterKeyCommand([keyCommand]);
+    };
+}
+
 export {
     registerKeyCommand,
     unregisterKeyCommand,
     constants,
     eventEmitter,
+    addListener,
 };


### PR DESCRIPTION
This PR adds iOS support for the key-command listener. 

```js
import {registerKeyCommand, constants, eventEmitter} from 'react-native-key-command';

/**
 * Register a command for [k + CMD] combination
 */
registerKeyCommand([
  {input: 'd', modifierFlags: constants.keyModifierCommand},
]);

/**
 * Add an event listener
 */
eventEmitter.addListener('onKeyCommand', console.log);
```

## Demo
- (both `/` and `/example`)
- npm install
- pod install
- npm run ios
- connect hardware keyboard on simulator
- change event listener callback (e.g. `console.log`) here https://github.com/Expensify/react-native-key-command/pull/3/files#diff-70aa9f24302e170717b76b7501425ccf9cb910991099eaef6b17a18cdac37dbfR21
- press `CMD + d`

<img width="555" alt="Screen Shot 2022-08-23 at 16 26 29" src="https://user-images.githubusercontent.com/4882133/186146522-1fee2fd6-83ad-48cd-968f-24e049b3be7e.png">

