### PR TITLE
Add missing control+shift combination for android

### DIFF
--- a/android/src/main/java/com/expensify/reactnativekeycommand/KeyCommandModule.java
+++ b/android/src/main/java/com/expensify/reactnativekeycommand/KeyCommandModule.java
@@ -94,7 +94,10 @@ public class KeyCommandModule extends ReactContextBaseJavaModule {
          * using isPressed method makes comparision by modifier mask
          */
         int modifierFlags = 0;
-        if (keyEvent.isCtrlPressed()) {
+        if (keyEvent.isCtrlPressed() && keyEvent.isShiftPressed()) {
+            modifierFlags = KeyEvent.META_CTRL_MASK | KeyEvent.META_SHIFT_MASK;
+        }
+        else if (keyEvent.isCtrlPressed()) {
             modifierFlags = KeyEvent.META_CTRL_MASK;
         }
         else if (keyEvent.isAltPressed()) {
@@ -137,6 +140,8 @@ public class KeyCommandModule extends ReactContextBaseJavaModule {
 
         constants.put("keyModifierShift", KeyEvent.META_SHIFT_MASK);
         constants.put("keyModifierControl", KeyEvent.META_CTRL_MASK);
+        constants.put("keyModifierShiftCommand", KeyEvent.META_CTRL_MASK | KeyEvent.META_SHIFT_MASK);
+        constants.put("keyModifierShiftControl", KeyEvent.META_CTRL_MASK | KeyEvent.META_SHIFT_MASK);
         constants.put("keyModifierAlternate", KeyEvent.META_ALT_MASK);
         constants.put("keyModifierCommand", KeyEvent.META_CTRL_MASK);
         constants.put("keyModifierNumericPad", KeyEvent.KEYCODE_NUM);

--- a/android/src/main/java/com/expensify/reactnativekeycommand/KeyCommandModule.java
+++ b/android/src/main/java/com/expensify/reactnativekeycommand/KeyCommandModule.java
@@ -105,9 +105,24 @@ public class KeyCommandModule extends ReactContextBaseJavaModule {
         }
         else if (keyEvent.isShiftPressed()) {
             modifierFlags = KeyEvent.META_SHIFT_MASK;
-        } else if (keyEvent.getKeyCode() == KeyEvent.KEYCODE_ESCAPE) {
-            // handle Esc key
+        }
+        else if (keyEvent.getKeyCode() == KeyEvent.KEYCODE_ESCAPE) {
             modifierFlags = KeyEvent.KEYCODE_ESCAPE;
+        }
+        else if (keyEvent.getKeyCode() == KeyEvent.KEYCODE_DPAD_UP) {
+            modifierFlags = KeyEvent.KEYCODE_DPAD_UP;
+        }
+        else if (keyEvent.getKeyCode() == KeyEvent.KEYCODE_DPAD_DOWN) {
+            modifierFlags = KeyEvent.KEYCODE_DPAD_DOWN;
+        }
+        else if (keyEvent.getKeyCode() == KeyEvent.KEYCODE_DPAD_LEFT) {
+            modifierFlags = KeyEvent.KEYCODE_DPAD_LEFT;
+        }
+        else if (keyEvent.getKeyCode() == KeyEvent.KEYCODE_DPAD_RIGHT) {
+            modifierFlags = KeyEvent.KEYCODE_DPAD_RIGHT;
+        }
+        else if (keyEvent.getKeyCode() == KeyEvent.KEYCODE_ENTER) {
+            modifierFlags = KeyEvent.KEYCODE_ENTER;
         }
 
         /**
@@ -119,6 +134,10 @@ public class KeyCommandModule extends ReactContextBaseJavaModule {
             .toLowerCase();
         if (!displayLabel.isEmpty()) {
             input = displayLabel;
+        }
+        if (keyEvent.getKeyCode() == KeyEvent.KEYCODE_ENTER && keyEvent.isCtrlPressed()) {
+            input = Integer.toString(KeyEvent.KEYCODE_ENTER);
+            modifierFlags = KeyEvent.META_CTRL_MASK;
         }
 
         params.putInt("modifierFlags", modifierFlags);
@@ -150,6 +169,7 @@ public class KeyCommandModule extends ReactContextBaseJavaModule {
         constants.put("keyInputLeftArrow", KeyEvent.KEYCODE_DPAD_LEFT);
         constants.put("keyInputRightArrow", KeyEvent.KEYCODE_DPAD_RIGHT);
         constants.put("keyInputEscape", KeyEvent.KEYCODE_ESCAPE);
+        constants.put("keyInputEnter", KeyEvent.KEYCODE_ENTER);
 
         return constants;
     }

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -51,6 +51,11 @@ export default function App() {
         return KeyCommand.addListener(KEY_COMMAND, () => handleSearchCommandPress('[G] pressed'));
     }, []);
 
+    React.useEffect(() => {
+        const KEY_COMMAND = {input: 'k', modifierFlags: KeyCommand.constants.keyModifierShiftControl};
+        return KeyCommand.addListener(KEY_COMMAND, () => handleSearchCommandPress('[CMD + SHIFT + K] pressed'));
+    }, []);
+
     return (
         <SafeAreaView style={styles.container}>
             <View style={styles.header}>
@@ -58,6 +63,7 @@ export default function App() {
                 <Text style={styles.title}>1. [CMD + F]</Text>
                 <Text style={styles.title}>2. [G]</Text>
                 <Text style={styles.title}>3. [Esc]</Text>
+                <Text style={styles.title}>3. [CMD + SHIFT + K]</Text>
             </View>
 
             <ScrollView style={styles.scroll}>

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -56,6 +56,21 @@ export default function App() {
         return KeyCommand.addListener(KEY_COMMAND, () => handleSearchCommandPress('[CMD + SHIFT + K] pressed'));
     }, []);
 
+    React.useEffect(() => {
+        const KEY_COMMAND = {input: KeyCommand.constants.keyInputEnter};
+        return KeyCommand.addListener(KEY_COMMAND, () => handleSearchCommandPress('[Enter] pressed'));
+    }, []);
+
+    React.useEffect(() => {
+        const KEY_COMMAND = {input: KeyCommand.constants.keyInputDownArrow};
+        return KeyCommand.addListener(KEY_COMMAND, () => handleSearchCommandPress('[Down arrow] pressed'));
+    }, []);
+
+    React.useEffect(() => {
+        const KEY_COMMAND = {input: KeyCommand.constants.keyInputUpArrow};
+        return KeyCommand.addListener(KEY_COMMAND, () => handleSearchCommandPress('[Up arrow] pressed'));
+    }, []);
+
     return (
         <SafeAreaView style={styles.container}>
             <View style={styles.header}>
@@ -63,7 +78,9 @@ export default function App() {
                 <Text style={styles.title}>1. [CMD + F]</Text>
                 <Text style={styles.title}>2. [G]</Text>
                 <Text style={styles.title}>3. [Esc]</Text>
-                <Text style={styles.title}>3. [CMD + SHIFT + K]</Text>
+                <Text style={styles.title}>4. [CMD + SHIFT + K]</Text>
+                <Text style={styles.title}>5. [ENTER]</Text>
+                <Text style={styles.title}>6. [DOWN / UP ARROW]</Text>
             </View>
 
             <ScrollView style={styles.scroll}>


### PR DESCRIPTION
This PR adds Android support for:
- Arrow keys
- Enter
- Ctrl + Shift
- Ctrl + Enter