### PR TITLE
Bump to v0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-key-command",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-key-command",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A cross-platform module that registers and listens to specified keyboard events, dispatching the payload to JavaScript",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Updates the package to v0.6 to release the [new version to npm](https://www.npmjs.com/package/react-native-key-command)