### PR TITLE
Prevent subscribing to keycommands on non browser environments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-key-command",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-key-command",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A cross-platform module that registers and listens to specified keyboard events, dispatching the payload to JavaScript",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/KeyCommand/index.js
+++ b/src/KeyCommand/index.js
@@ -182,8 +182,11 @@ function unregisterKeyCommands(keyCommands) {
     });
 }
 
-document.removeEventListener('keydown', onKeyDown, {capture: true});
-document.addEventListener('keydown', onKeyDown, {capture: true});
+// `window` is not available, so `window.document` (or simply `document`) will fail.
+if (typeof window !== 'undefined') {
+    document.removeEventListener('keydown', onKeyDown, {capture: true});
+    document.addEventListener('keydown', onKeyDown, {capture: true});
+}
 
 export default {
     getConstants,


### PR DESCRIPTION
(electron) webpack build includes const file during compilation, hence build fails when document is used outside of main process.