### PR TITLE
Fix event key may be undefined

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-key-command",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-key-command",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A cross-platform module that registers and listens to specified keyboard events, dispatching the payload to JavaScript",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/KeyCommand/index.js
+++ b/src/KeyCommand/index.js
@@ -132,7 +132,11 @@ function getRegisteredCommandIndex(json) {
  */
 function getMatchedInputIndex(event) {
     const modifierFlags = getKeyEventModifiers(event);
-    return getRegisteredCommandIndex({input: event.key.toLowerCase(), modifierFlags});
+
+    // Event key may be undefined in some cases, such as when autocomplete is used on a text input
+    const input = event.key ? event.key.toLowerCase() : undefined;
+
+    return getRegisteredCommandIndex({input, modifierFlags});
 }
 
 function onKeyDown(event) {


### PR DESCRIPTION
Event key may be undefined in some cases, such as when autocomplete is used on a text input:

```js
event → {
  isTrusted: true,
  bubbles: true,
  cancelBubble: false,
  cancelable: false,
  composed: false,
  currentTarget: document,
  defaultPrevented: false,
  eventPhase: 1,
  returnValue: true,
  srcElement: input#username.css-textinput-11aywtz.r-placeholderTextColor-6taxm2,
  target: input#username.css-textinput-11aywtz.r-placeholderTextColor-6taxm2,
  timeStamp: 5583.5,
  type: "keydown"
}
```