### PR TITLE
Update podspec to not rely on hardcoded `folly_version`

### DIFF
--- a/react-native-key-command.podspec
+++ b/react-native-key-command.podspec
@@ -1,7 +1,6 @@
 require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
-folly_version = '2021.06.28.00-v2'
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
@@ -27,10 +26,5 @@ Pod::Spec.new do |s|
         "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
     }
 
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly", folly_version
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
-  end
+    install_modules_dependencies(s)
 end


### PR DESCRIPTION
Instead of manually specifying dependencies, we can rely on React Native to do this (see https://reactnative.dev/docs/new-architecture-library-ios#add-folly-and-other-dependencies). This way we can avoid problems like hardcoded versions being incompatible with newer versions of RN.

`install_modules_dependencies` however, was introduced in React Native 0.71. This means that this PR makes the library incompatible with RN versions below 0.71 when using the new architecture.