### PR TITLE
fix: publish script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,7 @@ jobs:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Build package
-              run: npm run build
+              run: npm run prepare
 
             - name: Publish to npm
               run: npm publish


### PR DESCRIPTION
We tried to add auto publishing in [this PR](https://github.com/Expensify/Expensify/issues/269898), but the package doesn't have a build script 🤦 so the workflow [failed](https://github.com/Expensify/react-native-key-command/actions/runs/5753454381/job/15596688029).

This PR uses the correct script in the workflow.

$ https://github.com/Expensify/Expensify/issues/269898