### PR TITLE
fix: dont make deps so restrictive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,10 +32,10 @@
         "release-it": "^15.0.0"
       },
       "peerDependencies": {
-        "react": "^18.1.0",
-        "react-dom": "18.1.0",
-        "react-native": "^0.70.4",
-        "react-native-web": "^0.19.7"
+        "react": ">=18.1.0",
+        "react-dom": ">=18.1.0",
+        "react-native": ">=0.70.4",
+        "react-native-web": ">=0.19.7"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -61,10 +61,10 @@
     "release-it": "^15.0.0"
   },
   "peerDependencies": {
-    "react": "^18.1.0",
-    "react-dom": "18.1.0",
-    "react-native": "^0.70.4",
-    "react-native-web": "^0.19.7"
+    "react": ">=18.1.0",
+    "react-dom": ">=18.1.0",
+    "react-native": ">=0.70.4",
+    "react-native-web": ">=0.19.7"
   },
   "jest": {
     "testEnvironment": "jest-environment-jsdom",


### PR DESCRIPTION
When trying to remove `react-native` and some others from `overrides` in ND repo, this library is the one blocking it since it wants very strict versions of libs for no reason.